### PR TITLE
remove body-parser (part of express since 4.16/17.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ This source code is provided under EUPL v1.2, except for the [`spdx-exceptions`]
 | NPM     | `@google-cloud/datastore`      | [Apache License 2.0](https://github.com/googleapis/nodejs-datastore/blob/master/LICENSE)           |
 | NPM     | `@google-cloud/pubsub`         | [Apache License 2.0](https://github.com/googleapis/nodejs-pubsub/blob/master/LICENSE)              |
 | NPM     | `@google-cloud/secret-manager` | [Apache License 2.0](https://github.com/googleapis/nodejs-secret-manager/blob/master/LICENSE)      |
-| NPM     | `body-parser`                  | [MIT](https://github.com/expressjs/body-parser/blob/master/LICENSE)                                |
 | NPM     | `compression`                  | [MIT](https://github.com/expressjs/compression/blob/master/LICENSE)                                |
 | NPM     | `dd-trace`                     | [Apache-2.0 OR BSD-3-Clause](https://github.com/DataDog/dd-trace-js/blob/master/LICENSE)           |
 | NPM     | `express`                      | [MIT](https://github.com/expressjs/express/blob/master/LICENSE)                                    |

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"@google-cloud/datastore": "^6.4.0",
 		"@google-cloud/pubsub": "^2.12.0",
 		"@google-cloud/secret-manager": "^3.7.1",
-		"body-parser": "^1.19.0",
 		"compression": "^1.7.4",
 		"dd-trace": "^0.34.0",
 		"express": "4.17.1",

--- a/src/ingest/router.js
+++ b/src/ingest/router.js
@@ -8,7 +8,6 @@
 // import express.router
 const express = require('express')
 const moment = require('moment')
-const bodyParser = require('body-parser')
 const OpenApiValidator = require('express-openapi-validator')
 
 // load swagger UI
@@ -21,7 +20,7 @@ const router = express.Router()
 router.use(express.urlencoded({ extended: true }))
 
 // enable body parsing for post requests
-router.use(bodyParser.json())
+router.use(express.json())
 
 // load openapi validator
 router.use(


### PR DESCRIPTION
Remove deprecated body-parser middleware as it's builtin since express v.4.16/17.0 ([Express 4.x-API](https://expressjs.com/de/api.html))