### PR TITLE
Switch yarn cache

### DIFF
--- a/.github/workflows/ingest-pull.yml
+++ b/.github/workflows/ingest-pull.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout repo 👀
       uses: actions/checkout@v2.3.4
 
-    - uses: actions/setup-node@v2.4.0
+    - uses: actions/setup-node@v2.4.1
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'yarn'
@@ -60,7 +60,7 @@ jobs:
     - name: Checkout repo 👀
       uses: actions/checkout@v2.3.4
 
-    - uses: actions/setup-node@v2.4.0
+    - uses: actions/setup-node@v2.4.1
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'yarn'

--- a/.github/workflows/ingest-push.yml
+++ b/.github/workflows/ingest-push.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout repo 👀
       uses: actions/checkout@v2.3.4
 
-    - uses: actions/setup-node@v2.4.0
+    - uses: actions/setup-node@v2.4.1
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'yarn'


### PR DESCRIPTION
This simply removes the direct dependency to `actions/cache` and uses the same integration through `actions/setup-node`.