### PR TITLE
docs(agents): add Cursor Cloud development environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,12 @@ Follow SWR Audio Lab engineering principles:
 - Keep dependencies up-to-date for security patches
 - Test thoroughly after dependency upgrades
 - Check license compatibility (project uses EUPL-1.2)
+
+## Cursor Cloud specific instructions
+
+Runtime is **Bun** (installed at `~/.bun`; the startup update script runs `bun install`). Standard commands live in `package.json`/`justfile` (see "Setup Commands" above); only the non-obvious caveats are noted here.
+
+- **No emulators / no offline mode.** Pub/Sub, Datastore, and Firebase clients connect to **live Google Cloud**, and `ARD_FEED_URL` is an internal ARD endpoint (itself a secret). There is no `docker-compose` or local emulator wiring.
+- **Secrets are not present in the cloud VM by default.** Real auth, event publishing, and the full test suite need `sops`-decrypted `.env.sops.yaml` (requires the age/PGP key) plus `TEST_USER`/`TEST_USER_PW`. Without them, `just test` and `bun test src/ingest/ingest.test.ts` fail at the env/secret gate, and GCP/Firebase-backed routes return 401/500. If you need these, ask the user to provide the secrets.
+- **Runs without secrets:** `bun run lint`, and the two unit tests `bun test src/ingest/middleware/validationError.test.ts` and `bun test scripts/generate-openapi.test.ts`. `sops`/`just` are not installed by the update script.
+- **Booting the server for a smoke test without secrets:** `src/ingest/index.ts` calls `getARDFeed()` at startup and `process.exit(1)`s if `ARD_FEED_URL` is unreachable; `config/index.ts`, `config/dts-keys.ts` (base64 JSON `DTS_KEYS`), and the radioplayer plugin (base64 JSON `RADIOPLAYER_API_KEYS`) are all validated/parsed at import. You can boot `bun run ingest` with placeholder env vars + a mock feed served locally (≥190 items including stations `WDR 2, WDR 4, 1LIVE, NDR 1 Niedersachsen, SWR3, NDR 2, BAYERN 1, SWR4 BW, hr3, hr4`) to exercise routing/middleware/Zod validation and the `/openapi` Swagger UI; backend-dependent routes will still 401/500.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for ARD Eventhub on Cursor Cloud and documents durable, non-obvious run caveats for future agents.

- Configured the startup update script to `~/.bun/bin/bun install`.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering: no emulators / live-GCP dependency, which commands run without secrets, and how to boot the ingest service for a smoke test using placeholder env vars + a mock ARD feed.

No application code was modified.

## Environment verification

| Check | Command | Result |
| --- | --- | --- |
| Install | `bun install` | ✅ 1076 packages |
| Lint | `bun run lint` | ✅ exit 0 (15 warnings) |
| Unit tests | `bun test src/ingest/middleware/validationError.test.ts` | ✅ 3 pass |
| Unit tests | `bun test scripts/generate-openapi.test.ts` | ✅ 2 pass |
| Run | `bun run ingest` | ✅ boots; `/`, `/health`, `/openapi` → 200 |
| Full suite | `bun test src/ingest/ingest.test.ts` | ⚠️ requires live secrets (GCP/Firebase/ARD feed, `TEST_USER`) |

The ingest service was booted with placeholder config env vars and a locally-served mock ARD feed (live GCP/Firebase/`ARD_FEED_URL` secrets are not available in the cloud VM). Auth middleware (`401`), Zod validation (structured `400`), health, and the OpenAPI Swagger UI were all exercised end-to-end.

[ard_eventhub_openapi_demo.mp4](https://cursor.com/agents/bc-470f8338-0ef4-4dbe-a041-10ed986a26f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fard_eventhub_openapi_demo.mp4)

[ARD Eventhub OpenAPI UI loaded](https://cursor.com/agents/bc-470f8338-0ef4-4dbe-a041-10ed986a26f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenapi_ui_loaded.webp)
[POST /auth/login executed against the running server](https://cursor.com/agents/bc-470f8338-0ef4-4dbe-a041-10ed986a26f6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenapi_login_response.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-470f8338-0ef4-4dbe-a041-10ed986a26f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-470f8338-0ef4-4dbe-a041-10ed986a26f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

